### PR TITLE
Make Time, RealTimeTrip, and StopTimeUpdate interface properties optional

### DIFF
--- a/src/realtime.def.ts
+++ b/src/realtime.def.ts
@@ -20,18 +20,18 @@ export enum Congestion {
 }
 
 declare interface Time {
-  delay: number;
-  time: number;
-  uncertainty: number;
+  delay?: number;
+  time?: number;
+  uncertainty?: number;
 }
 
 interface RealTimeTrip {
-  trip_id: string;
-  start_time: string;
-  start_date: string;
-  schedule_relationship: TripScheduleRelationship;
-  route_id: string;
-  direction_id: number;
+  trip_id?: string;
+  start_time?: string;
+  start_date?: string;
+  schedule_relationship?: TripScheduleRelationship;
+  route_id?: string;
+  direction_id?: number;
 }
 
 export enum TripScheduleRelationship {
@@ -48,9 +48,9 @@ export enum StopTimeUpdateScheduleRelationship {
 }
 
 export interface Vehicle {
-  id: string;
-  label: string;
-  license_plate: string;
+  id?: string;
+  label?: string;
+  license_plate?: string;
 }
 
 export interface TripUpdate {
@@ -141,11 +141,11 @@ export interface Position {
 }
 
 export interface StopTimeUpdate {
-  stop_sequence: number;
-  stop_id: string;
+  stop_sequence?: number;
+  stop_id?: string;
   arrival?: Time;
   departure?: Time;
-  schedule_relationship: StopTimeUpdateScheduleRelationship;
+  schedule_relationship?: StopTimeUpdateScheduleRelationship;
 }
 
 export interface EntitySelector {


### PR DESCRIPTION
It's me again!
My feeds are not compatible with the current types so I wanted to make this update.

When the [spec](https://gtfs.org/realtime/reference) specified a field as _Conditionally required_ I made the property optional. Below is an excerpt from a TripUpdate feed from Sweden.

<details>
<summary>Feed</summary>
  
```
entity {
  id: "14010516182011315"
  trip_update {
    trip {
      trip_id: "14010000660994806"
      start_date: "20240521"
      schedule_relationship: SCHEDULED
    }
    stop_time_update {
      stop_sequence: 34
      arrival {
        delay: 0
        time: 1716317220
      }
      departure {
        delay: 0
        time: 1716317220
      }
      stop_id: "9022001000306001"
    }
    stop_time_update {
      stop_sequence: 35
      arrival {
        delay: 0
        time: 1716317400
      }
      departure {
        delay: 0
        time: 1716317400
      }
      stop_id: "9022001000301001"
    }
    vehicle {
      id: "9031008000500547"
    }
    timestamp: 1716316188
  }
}
entity {
  id: "14050001704887972"
  trip_update {
    trip {
      start_time: "18:27:22"
      start_date: "20240521"
      schedule_relationship: CANCELED
      route_id: "9011001001700000"
      direction_id: 1
    }
    stop_time_update {
      stop_sequence: 1
      arrival {
        delay: 0
        time: 1716308842
      }
      departure {
        delay: 0
        time: 1716308842
      }
      stop_id: "9022001001951002"
    }
    stop_time_update {
      stop_sequence: 2
      arrival {
        delay: 0
        time: 1716308842
        uncertainty: 0
      }
      departure {
        delay: 0
        time: 1716308842
      }
      stop_id: "9022001001951001"
    }
    stop_time_update {
      stop_sequence: 3
      arrival {
        delay: 0
        time: 1716308842
      }
      departure {
        delay: 0
        time: 1716308842
      }
      stop_id: "9022001001941001"
    }
    stop_time_update {
      stop_sequence: 4
      arrival {
        delay: 0
        time: 1716308842
      }
      departure {
        delay: 0
        time: 1716308842
      }
      stop_id: "9022001001941002"
    }
    vehicle {
      id: "9031001002500096"
    }
    timestamp: 1716308843
  }
}
```
</details>